### PR TITLE
refactor: use docker compose for deployment

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -120,7 +120,7 @@ jobs:
           CI_SSH_PUBLIC_KEY: ${{ vars.CI_SSH_PUBLIC_KEY }}
           ADMIN_SSH_KEY_NAME: ${{ vars.ADMIN_SSH_KEY_NAME }}
           ADMIN_SSH_PUBLIC_KEY: ${{ vars.ADMIN_SSH_PUBLIC_KEY }}
-          WEBSITE_VERSION: ${{ needs.build-and-push.outputs.image_tag }}
+          WEBSITE_VERSION: ${{ github.ref == 'refs/heads/main' && needs.build-and-push.outputs.image_tag || 'latest' }}
           GCLOUD_DNS_ZONE: 'takuto-de'
           FORCE_RECREATE: "${{ inputs.force_recreate }}"
         run: |

--- a/ansible/roles/deploy/tasks/main.yml
+++ b/ansible/roles/deploy/tasks/main.yml
@@ -10,19 +10,18 @@
     - /opt/nginx-proxy/vhost.d
     - /opt/nginx-proxy/html
     - /opt/nginx-proxy/certs
-    - /opt/nginx-proxy/gcloud-dns
+    - /opt/takuto-website
     - /opt/takuto-website/uploads
 
-- name: Create Google Cloud DNS service account key file
+- name: Copy docker-compose files to deployment directory
   copy:
-    content: "{{ gcloud_dns_service_account }}"
-    dest: /opt/nginx-proxy/gcloud-dns/credentials.json
-    mode: '0600'
+    src: "{{ playbook_dir }}/../{{ item }}"
+    dest: /opt/takuto-website/
+    mode: '0644'
+  loop:
+    - "docker-compose.yml"
+    - "docker-compose.prod.yml"
 
-- name: Create Docker network for nginx-proxy
-  community.docker.docker_network:
-    name: nginx-proxy
-    driver: bridge
 
 - name: Pull Docker image for the website
   community.docker.docker_image:
@@ -31,65 +30,21 @@
     force_source: yes
     state: present
 
-- name: Run website container
-  community.docker.docker_container:
-    name: takuto-website
-    image: "ghcr.io/takuto88/takuto-de:{{ website_version }}"
-    state: started
-    restart_policy: always
-    image_name_mismatch: "recreate"
-    networks:
-      - name: nginx-proxy
-    volumes:
-      - /opt/takuto-website/uploads:/usr/share/nginx/html/uploads:ro
-    env:
-      VIRTUAL_HOST: "{{ domains | join(',') }}"
-      VIRTUAL_PORT: "80"
-      LETSENCRYPT_HOST: "{{ domains | join(',') }}"
-    restart: yes
+- name: Create environment file for Docker Compose
+  copy:
+    content: |
+      EMAIL_FOR_CERTBOT={{ email_for_certbot }}
+      DOMAINS_STR={{ domains | join(',') }}
+      WEBSITE_VERSION={{ website_version }}
+    dest: /opt/takuto-website/.env
+    mode: '0600'
 
-- name: Deploy nginx-proxy container
-  community.docker.docker_container:
-    name: nginx-proxy
-    image: nginxproxy/nginx-proxy:latest
-    state: started
-    restart_policy: always
-    networks:
-      - name: nginx-proxy
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - /opt/nginx-proxy/conf.d:/etc/nginx/conf.d
-      - /opt/nginx-proxy/vhost.d:/etc/nginx/vhost.d
-      - /opt/nginx-proxy/html:/usr/share/nginx/html
-      - /opt/nginx-proxy/certs:/etc/nginx/certs:ro
-      - /var/run/docker.sock:/tmp/docker.sock:ro
-    restart: yes
-
-- name: Deploy letsencrypt-companion container
-  community.docker.docker_container:
-    name: letsencrypt-companion
-    image: nginxproxy/acme-companion:latest
-    state: started
-    restart_policy: always
-    networks:
-      - name: nginx-proxy
-    volumes:
-      - /opt/nginx-proxy/certs:/etc/nginx/certs
-      - /opt/nginx-proxy/vhost.d:/etc/nginx/vhost.d
-      - /opt/nginx-proxy/html:/usr/share/nginx/html
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /opt/nginx-proxy/gcloud-dns:/gcloud-dns
-    volumes_from:
-      - nginx-proxy
-    env:
-      DEFAULT_EMAIL: "{{ email_for_certbot }}"
-      ACME_CA_URI: "https://acme-v02.api.letsencrypt.org/directory"
-      NGINX_PROXY_CONTAINER: nginx-proxy
-      ACME_CHALLENGE_TYPE: "dns-01"
-      ACME_DNS_API: "gcloud"
-      GCE_PROJECT: "{{ (gcloud_dns_service_account.project_id) if (gcloud_dns_service_account is mapping) else (gcloud_dns_service_account | from_json | json_query('project_id')) }}"
-      GCE_SERVICE_ACCOUNT_FILE: "/gcloud-dns/credentials.json"
-      GCE_ZONE_NAME: "{{ gcloud_dns_zone }}"
-    restart: yes
+- name: Run website with Docker Compose
+  community.docker.docker_compose_v2:
+    project_src: /opt/takuto-website
+    files:
+      - docker-compose.yml
+      - docker-compose.prod.yml
+    state: present
+    env_files:
+      - .env

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -35,6 +35,7 @@
       - docker-ce
       - docker-ce-cli
       - containerd.io
+      - docker-compose-plugin
     state: present
     update_cache: yes
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,47 @@
+services:
+  web:
+    image: ghcr.io/takuto88/takuto-de:${WEBSITE_VERSION}
+    volumes:
+      - /opt/takuto-website/uploads:/usr/share/nginx/html/uploads:ro
+    networks:
+      - nginx-proxy
+    environment:
+      - VIRTUAL_HOST=${DOMAINS_STR}
+      - VIRTUAL_PORT=80
+      - LETSENCRYPT_HOST=${DOMAINS_STR}
+
+  nginx-proxy:
+    image: nginxproxy/nginx-proxy:1.10.2
+    container_name: nginx-proxy
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    networks:
+      - nginx-proxy
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - /opt/nginx-proxy/conf.d:/etc/nginx/conf.d
+      - /opt/nginx-proxy/vhost.d:/etc/nginx/vhost.d
+      - /opt/nginx-proxy/html:/usr/share/nginx/html
+      - /opt/nginx-proxy/certs:/etc/nginx/certs:ro
+
+  acme-companion:
+    image: nginxproxy/acme-companion:2.6.3
+    container_name: letsencrypt-companion
+    restart: always
+    networks:
+      - nginx-proxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /opt/nginx-proxy/certs:/etc/nginx/certs
+      - /opt/nginx-proxy/vhost.d:/etc/nginx/vhost.d
+      - /opt/nginx-proxy/html:/usr/share/nginx/html
+    environment:
+      DEFAULT_EMAIL: "${EMAIL_FOR_CERTBOT}"
+      ACME_CA_URI: "https://acme-v02.api.letsencrypt.org/directory"
+      NGINX_PROXY_CONTAINER: nginx-proxy
+
+networks:
+  nginx-proxy:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,5 @@ services:
     image: ghcr.io/takuto88/takuto-de:latest
     ports:
       - "80:80"
+    volumes:
+      - ./src:/usr/share/nginx/html


### PR DESCRIPTION
This PR refactors the deployment process to use docker-compose instead of individual docker_container tasks in Ansible. This allows for easier management of the container stack and enables Dependabot to automatically update the proxy and companion images via docker-compose.yml.